### PR TITLE
 Configure SPIRE Server socket path via file

### DIFF
--- a/api/v1alpha1/controllermanagerconfig_types.go
+++ b/api/v1alpha1/controllermanagerconfig_types.go
@@ -50,6 +50,9 @@ type ControllerManagerConfig struct {
 	// after CRDs are removed or SPIRE state is mutated out from underneath
 	// the controller.
 	GCInterval time.Duration `json:"gcInterval"`
+
+	// SPIREServerSocketPath is the path to the SPIRE Server API socket
+	SPIREServerSocketPath string `json:"spireServerSocketPath"`
 }
 
 func init() {

--- a/docs/spire-controller-manager-config.md
+++ b/docs/spire-controller-manager-config.md
@@ -4,10 +4,11 @@ The SPIRE Controller Manager configuration is defined [here](../api/v1alpha1/con
 
 Beyond the standard [controller manager configuration](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/config/v1alpha1#ControllerConfigurationSpec), the following fields are defined:
 
-| Field                                | Required | Description                                                                                                             |
-| ------------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `clusterName`                        | REQUIRED | The name of the cluster |
-| `trustDomain`                        | REQUIRED | The trust domain name for the cluster |
-| `ignoreNamespaces`                   | OPTIONAL | Namespaces that the controllers should ignore. Defaults to `kube-system`, `kube-public`, and `spire-system` |
-| `validatingWebhookConfigurationName` | OPTIONAL | The name of the validating admission controller webhook to manage. Defaults to `spire-controller-manager-webhook`. |
-| `gcInterval`                         | OPTIONAL | How often the SPIRE state is reconciled when the controller is otherwise idle. This impacts how quickly SPIRE state will converge after CRDs are removed or SPIRE state is mutated underneath the controller. Defaults to 10 seconds. |
+| Field                                | Required | Default                                          | Description                                                                                                             |
+| ------------------------------------ | -------- | ------------------------------------------------ | ------------------------------------------------------------------ |
+| `clusterName`                        | REQUIRED |                                                  | The name of the cluster |
+| `trustDomain`                        | REQUIRED |                                                  | The trust domain name for the cluster |
+| `ignoreNamespaces`                   | OPTIONAL | `["kube-system", "kube-public", "spire-system"]` | Namespaces that the controllers should ignore |
+| `validatingWebhookConfigurationName` | OPTIONAL | `spire-controller-manager-webhook`               | The name of the validating admission controller webhook to manage |
+| `gcInterval`                         | OPTIONAL | `10s`                                            | How often the SPIRE state is reconciled when the controller is otherwise idle. This impacts how quickly SPIRE state will converge after CRDs are removed or SPIRE state is mutated underneath the controller. |
+| `spireServerSocketPath`              | OPTIONAL | `/spire-server/api.sock`                         | The path the the SPIRE Server API socket |


### PR DESCRIPTION
Also deprecates the CLI flag option.
    
Fixes: #27