### PR TITLE
Fix entry key creation

### DIFF
--- a/pkg/spireentry/reconciler.go
+++ b/pkg/spireentry/reconciler.go
@@ -359,7 +359,7 @@ func makeEntryKey(entry spireapi.Entry) entryKey {
 
 func sortSelectors(unsorted []spireapi.Selector) []spireapi.Selector {
 	sorted := append([]spireapi.Selector(nil), unsorted...)
-	sort.Slice(unsorted, func(i, j int) bool {
+	sort.Slice(sorted, func(i, j int) bool {
 		switch {
 		case sorted[i].Type < sorted[j].Type:
 			return true


### PR DESCRIPTION
Selectors were not properly sorted when generating entry keys, resulting in two entries with the same selectors, but in a different order, having different keys. This caused the controller manager to delete all entries and recreate them on every reconciliation.

Fixes: #31