### PR TITLE
Fix status subresource in demo

### DIFF
--- a/api/v1alpha1/clusterspiffeid_webhook.go
+++ b/api/v1alpha1/clusterspiffeid_webhook.go
@@ -78,7 +78,7 @@ func (r *ClusterSPIFFEID) validate() error {
 	return err
 }
 
-//+kubebuilder:object:generate=false
+// +kubebuilder:object:generate=false
 // ParsedClusterSPIFFEIDSpec is a parsed and validated ClusterSPIFFEIDSpec
 type ParsedClusterSPIFFEIDSpec struct {
 	SPIFFEIDTemplate          *template.Template

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the spire v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=spire.spiffe.io
+// +kubebuilder:object:generate=true
+// +groupName=spire.spiffe.io
 package v1alpha1
 
 import (

--- a/demo/config/cluster1/crd/spire.spiffe.io_clusterfederatedtrustdomains.yaml
+++ b/demo/config/cluster1/crd/spire.spiffe.io_clusterfederatedtrustdomains.yaml
@@ -1,8 +1,10 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: clusterfederatedtrustdomains.spire.spiffe.io
 spec:
   group: spire.spiffe.io
@@ -13,76 +15,82 @@ spec:
     singular: clusterfederatedtrustdomain
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.trustDomain
-          name: Trust Domain
-          type: string
-        - jsonPath: .spec.bundleEndpointURL
-          name: Endpoint URL
-          type: string
-        - jsonPath: .spec.bundleEndpointProfile
-          name: Endpoint Profile
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ClusterFederatedTrustDomain is the Schema for the clusterfederatedtrustdomains
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - additionalPrinterColumns:
+    - jsonPath: .spec.trustDomain
+      name: Trust Domain
+      type: string
+    - jsonPath: .spec.bundleEndpointURL
+      name: Endpoint URL
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterFederatedTrustDomain is the Schema for the clusterfederatedtrustdomains
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ClusterFederatedTrustDomainSpec defines the desired state
-                of ClusterFederatedTrustDomain
-              properties:
-                bundleEndpointProfile:
-                  description: BundleEndpointProfile is the profile for the bundle endpoint.
-                  properties:
-                    endpointSPIFFEID:
-                      description: EndpointSPIFFEID is the SPIFFE ID of the bundle endpoint.
-                        It is required for the "https_spiffe" profile.
-                      type: string
-                    type:
-                      description: Type is the type of the bundle endpoint profile.
-                      enum:
-                        - https_spiffe
-                        - https_web
-                      type: string
-                  required:
-                    - type
-                  type: object
-                bundleEndpointURL:
-                  description: BundleEndpointURL is the URL of the bundle endpoint.
-                    It must be an HTTPS URL and cannot contain userinfo (i.e. username/password).
-                  type: string
-                trustDomain:
-                  description: TrustDomain is the name of the trust domain to federate
-                    with (e.g. example.org)
-                  pattern: '[a-z0-9._-]{1,255}'
-                  type: string
-                trustDomainBundle:
-                  description: TrustDomainBundle is the initial contents of the bundle
-                    for the referenced trust domain. This field is optional.
-                  type: string
-              required:
-                - bundleEndpointProfile
-                - bundleEndpointURL
-                - trustDomain
-              type: object
-            status:
-              description: ClusterFederatedTrustDomainStatus defines the observed state
-                of ClusterFederatedTrustDomain
-              type: object
-          type: object
-      served: true
-      storage: true
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterFederatedTrustDomainSpec defines the desired state
+              of ClusterFederatedTrustDomain
+            properties:
+              bundleEndpointProfile:
+                description: BundleEndpointProfile is the profile for the bundle endpoint.
+                properties:
+                  endpointSPIFFEID:
+                    description: EndpointSPIFFEID is the SPIFFE ID of the bundle endpoint.
+                      It is required for the "https_spiffe" profile.
+                    type: string
+                  type:
+                    description: Type is the type of the bundle endpoint profile.
+                    enum:
+                    - https_spiffe
+                    - https_web
+                    type: string
+                required:
+                - type
+                type: object
+              bundleEndpointURL:
+                description: BundleEndpointURL is the URL of the bundle endpoint.
+                  It must be an HTTPS URL and cannot contain userinfo (i.e. username/password).
+                type: string
+              trustDomain:
+                description: TrustDomain is the name of the trust domain to federate
+                  with (e.g. example.org)
+                pattern: '[a-z0-9._-]{1,255}'
+                type: string
+              trustDomainBundle:
+                description: TrustDomainBundle is the contents of the bundle for the
+                  referenced trust domain. This field is optional when the resource
+                  is created.
+                type: string
+            required:
+            - bundleEndpointProfile
+            - bundleEndpointURL
+            - trustDomain
+            type: object
+          status:
+            description: ClusterFederatedTrustDomainStatus defines the observed state
+              of ClusterFederatedTrustDomain
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/demo/config/cluster1/crd/spire.spiffe.io_clusterspiffeids.yaml
+++ b/demo/config/cluster1/crd/spire.spiffe.io_clusterspiffeids.yaml
@@ -1,8 +1,10 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: clusterspiffeids.spire.spiffe.io
 spec:
   group: spire.spiffe.io
@@ -13,199 +15,207 @@ spec:
     singular: clusterspiffeid
   scope: Cluster
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ClusterSPIFFEID is the Schema for the clusterspiffeids API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterSPIFFEID is the Schema for the clusterspiffeids API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ClusterSPIFFEIDSpec defines the desired state of ClusterSPIFFEID
-              properties:
-                admin:
-                  description: Admin indicates whether or not the SVID can be used to
-                    access the SPIRE administrative APIs. Extra care should be taken
-                    to only apply this SPIFFE ID to admin workloads.
-                  type: boolean
-                dnsNameTemplates:
-                  description: DNSNameTemplate represents templates for extra DNS names
-                    that are applicable to SVIDs minted for this ClusterSPIFFEID. The
-                    node and pod spec are made available to the template under .NodeSpec,
-                    .PodSpec respectively.
-                  items:
-                    type: string
-                  type: array
-                federatesWith:
-                  description: FederatesWith is a list of trust domain names that workloads
-                    that obtain this SPIFFE ID will federate with.
-                  items:
-                    type: string
-                  type: array
-                namespaceSelector:
-                  description: NamespaceSelector selects the namespaces that are targetted
-                    by this CRD.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the key
-                          and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship to
-                              a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
-                  type: object
-                podSelector:
-                  description: PodSelector selects the pods that are targetted by this
-                    CRD.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the key
-                          and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship to
-                              a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
-                  type: object
-                spiffeIDTemplate:
-                  description: SPIFFEID is the SPIFFE ID template. The node and pod
-                    spec are made available to the template under .NodeSpec, .PodSpec
-                    respectively.
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSPIFFEIDSpec defines the desired state of ClusterSPIFFEID
+            properties:
+              admin:
+                description: Admin indicates whether or not the SVID can be used to
+                  access the SPIRE administrative APIs. Extra care should be taken
+                  to only apply this SPIFFE ID to admin workloads.
+                type: boolean
+              dnsNameTemplates:
+                description: DNSNameTemplate represents templates for extra DNS names
+                  that are applicable to SVIDs minted for this ClusterSPIFFEID. The
+                  node and pod spec are made available to the template under .NodeSpec,
+                  .PodSpec respectively.
+                items:
                   type: string
-                ttl:
-                  description: TTL indicates an upper-bound time-to-live for SVIDs minted
-                    for this ClusterSPIFFEID. If unset, a default will be chosen.
+                type: array
+              federatesWith:
+                description: FederatesWith is a list of trust domain names that workloads
+                  that obtain this SPIFFE ID will federate with.
+                items:
                   type: string
-                workloadSelectorTemplates:
-                  description: WorkloadSelectorTemplates are templates to produce arbitrary
-                    workload selectors that apply to a given workload before it will
-                    receive this SPIFFE ID. The rendered value is interpreted by SPIRE
-                    and are of the form type:value, where the value may, and often does,
-                    contain semicolons, .e.g., k8s:container-image:docker/hello-world
-                    The node and pod spec are made available to the template under .NodeSpec,
-                    .PodSpec respectively.
-                  items:
-                    type: string
-                  type: array
-              required:
-                - spiffeIDTemplate
-              type: object
-            status:
-              description: ClusterSPIFFEIDStatus defines the observed state of ClusterSPIFFEID
-              properties:
-                stats:
-                  description: Stats produced by the last entry reconciliation run
-                  properties:
-                    entriesMasked:
-                      description: How many entries were masked by entries for other
-                        ClusterSPIFFEIDs. This happens when one or more ClusterSPIFFEIDs
-                        produce an entry for the same pod with the same set of workload
-                        selectors.
-                      type: integer
-                    entriesToSet:
-                      description: How many entries are to be set for this ClusterSPIFFEID.
-                        In nominal conditions, this should reflect the number of pods
-                        selected, but not always if there were problems encountered
-                        rendering an entry for the pod (RenderFailures) or entries are
-                        masked (EntriesMasked).
-                      type: integer
-                    entryFailures:
-                      description: How many entries were unable to be set due to failures
-                        to create or update the entries via the SPIRE Server API.
-                      type: integer
-                    namespacesIgnored:
-                      description: How many (selected) namespaces were ignored (based
-                        on configuration).
-                      type: integer
-                    namespacesSelected:
-                      description: How many namespaces were selected.
-                      type: integer
-                    podEntryRenderFailures:
-                      description: How many failures were encountered rendering an entry
-                        selected pods. This could be due to either a bad template in
-                        the ClusterSPIFFEID or Pod metadata that when applied to the
-                        template did not produce valid entry values.
-                      type: integer
-                    podsSelected:
-                      description: How many pods were selected out of the namespaces.
-                      type: integer
-                  type: object
-              type: object
-          type: object
-      served: true
-      storage: true
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector selects the namespaces that are targetted
+                  by this CRD.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              podSelector:
+                description: PodSelector selects the pods that are targetted by this
+                  CRD.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              spiffeIDTemplate:
+                description: SPIFFEID is the SPIFFE ID template. The node and pod
+                  spec are made available to the template under .NodeSpec, .PodSpec
+                  respectively.
+                type: string
+              ttl:
+                description: TTL indicates an upper-bound time-to-live for SVIDs minted
+                  for this ClusterSPIFFEID. If unset, a default will be chosen.
+                type: string
+              workloadSelectorTemplates:
+                description: WorkloadSelectorTemplates are templates to produce arbitrary
+                  workload selectors that apply to a given workload before it will
+                  receive this SPIFFE ID. The rendered value is interpreted by SPIRE
+                  and are of the form type:value, where the value may, and often does,
+                  contain semicolons, .e.g., k8s:container-image:docker/hello-world
+                  The node and pod spec are made available to the template under .NodeSpec,
+                  .PodSpec respectively.
+                items:
+                  type: string
+                type: array
+            required:
+            - spiffeIDTemplate
+            type: object
+          status:
+            description: ClusterSPIFFEIDStatus defines the observed state of ClusterSPIFFEID
+            properties:
+              stats:
+                description: Stats produced by the last entry reconciliation run
+                properties:
+                  entriesMasked:
+                    description: How many entries were masked by entries for other
+                      ClusterSPIFFEIDs. This happens when one or more ClusterSPIFFEIDs
+                      produce an entry for the same pod with the same set of workload
+                      selectors.
+                    type: integer
+                  entriesToSet:
+                    description: How many entries are to be set for this ClusterSPIFFEID.
+                      In nominal conditions, this should reflect the number of pods
+                      selected, but not always if there were problems encountered
+                      rendering an entry for the pod (RenderFailures) or entries are
+                      masked (EntriesMasked).
+                    type: integer
+                  entryFailures:
+                    description: How many entries were unable to be set due to failures
+                      to create or update the entries via the SPIRE Server API.
+                    type: integer
+                  namespacesIgnored:
+                    description: How many (selected) namespaces were ignored (based
+                      on configuration).
+                    type: integer
+                  namespacesSelected:
+                    description: How many namespaces were selected.
+                    type: integer
+                  podEntryRenderFailures:
+                    description: How many failures were encountered rendering an entry
+                      selected pods. This could be due to either a bad template in
+                      the ClusterSPIFFEID or Pod metadata that when applied to the
+                      template did not produce valid entry values.
+                    type: integer
+                  podsSelected:
+                    description: How many pods were selected out of the namespaces.
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/demo/config/cluster2/crd/spire.spiffe.io_clusterfederatedtrustdomains.yaml
+++ b/demo/config/cluster2/crd/spire.spiffe.io_clusterfederatedtrustdomains.yaml
@@ -1,8 +1,10 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: clusterfederatedtrustdomains.spire.spiffe.io
 spec:
   group: spire.spiffe.io
@@ -13,76 +15,82 @@ spec:
     singular: clusterfederatedtrustdomain
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.trustDomain
-          name: Trust Domain
-          type: string
-        - jsonPath: .spec.bundleEndpointURL
-          name: Endpoint URL
-          type: string
-        - jsonPath: .spec.bundleEndpointProfile
-          name: Endpoint Profile
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ClusterFederatedTrustDomain is the Schema for the clusterfederatedtrustdomains
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - additionalPrinterColumns:
+    - jsonPath: .spec.trustDomain
+      name: Trust Domain
+      type: string
+    - jsonPath: .spec.bundleEndpointURL
+      name: Endpoint URL
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterFederatedTrustDomain is the Schema for the clusterfederatedtrustdomains
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ClusterFederatedTrustDomainSpec defines the desired state
-                of ClusterFederatedTrustDomain
-              properties:
-                bundleEndpointProfile:
-                  description: BundleEndpointProfile is the profile for the bundle endpoint.
-                  properties:
-                    endpointSPIFFEID:
-                      description: EndpointSPIFFEID is the SPIFFE ID of the bundle endpoint.
-                        It is required for the "https_spiffe" profile.
-                      type: string
-                    type:
-                      description: Type is the type of the bundle endpoint profile.
-                      enum:
-                        - https_spiffe
-                        - https_web
-                      type: string
-                  required:
-                    - type
-                  type: object
-                bundleEndpointURL:
-                  description: BundleEndpointURL is the URL of the bundle endpoint.
-                    It must be an HTTPS URL and cannot contain userinfo (i.e. username/password).
-                  type: string
-                trustDomain:
-                  description: TrustDomain is the name of the trust domain to federate
-                    with (e.g. example.org)
-                  pattern: '[a-z0-9._-]{1,255}'
-                  type: string
-                trustDomainBundle:
-                  description: TrustDomainBundle is the initial contents of the bundle
-                    for the referenced trust domain. This field is optional.
-                  type: string
-              required:
-                - bundleEndpointProfile
-                - bundleEndpointURL
-                - trustDomain
-              type: object
-            status:
-              description: ClusterFederatedTrustDomainStatus defines the observed state
-                of ClusterFederatedTrustDomain
-              type: object
-          type: object
-      served: true
-      storage: true
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterFederatedTrustDomainSpec defines the desired state
+              of ClusterFederatedTrustDomain
+            properties:
+              bundleEndpointProfile:
+                description: BundleEndpointProfile is the profile for the bundle endpoint.
+                properties:
+                  endpointSPIFFEID:
+                    description: EndpointSPIFFEID is the SPIFFE ID of the bundle endpoint.
+                      It is required for the "https_spiffe" profile.
+                    type: string
+                  type:
+                    description: Type is the type of the bundle endpoint profile.
+                    enum:
+                    - https_spiffe
+                    - https_web
+                    type: string
+                required:
+                - type
+                type: object
+              bundleEndpointURL:
+                description: BundleEndpointURL is the URL of the bundle endpoint.
+                  It must be an HTTPS URL and cannot contain userinfo (i.e. username/password).
+                type: string
+              trustDomain:
+                description: TrustDomain is the name of the trust domain to federate
+                  with (e.g. example.org)
+                pattern: '[a-z0-9._-]{1,255}'
+                type: string
+              trustDomainBundle:
+                description: TrustDomainBundle is the contents of the bundle for the
+                  referenced trust domain. This field is optional when the resource
+                  is created.
+                type: string
+            required:
+            - bundleEndpointProfile
+            - bundleEndpointURL
+            - trustDomain
+            type: object
+          status:
+            description: ClusterFederatedTrustDomainStatus defines the observed state
+              of ClusterFederatedTrustDomain
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/demo/config/cluster2/crd/spire.spiffe.io_clusterspiffeids.yaml
+++ b/demo/config/cluster2/crd/spire.spiffe.io_clusterspiffeids.yaml
@@ -1,8 +1,10 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: clusterspiffeids.spire.spiffe.io
 spec:
   group: spire.spiffe.io
@@ -13,199 +15,207 @@ spec:
     singular: clusterspiffeid
   scope: Cluster
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ClusterSPIFFEID is the Schema for the clusterspiffeids API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterSPIFFEID is the Schema for the clusterspiffeids API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ClusterSPIFFEIDSpec defines the desired state of ClusterSPIFFEID
-              properties:
-                admin:
-                  description: Admin indicates whether or not the SVID can be used to
-                    access the SPIRE administrative APIs. Extra care should be taken
-                    to only apply this SPIFFE ID to admin workloads.
-                  type: boolean
-                dnsNameTemplates:
-                  description: DNSNameTemplate represents templates for extra DNS names
-                    that are applicable to SVIDs minted for this ClusterSPIFFEID. The
-                    node and pod spec are made available to the template under .NodeSpec,
-                    .PodSpec respectively.
-                  items:
-                    type: string
-                  type: array
-                federatesWith:
-                  description: FederatesWith is a list of trust domain names that workloads
-                    that obtain this SPIFFE ID will federate with.
-                  items:
-                    type: string
-                  type: array
-                namespaceSelector:
-                  description: NamespaceSelector selects the namespaces that are targetted
-                    by this CRD.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the key
-                          and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship to
-                              a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
-                  type: object
-                podSelector:
-                  description: PodSelector selects the pods that are targetted by this
-                    CRD.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the key
-                          and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship to
-                              a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
-                  type: object
-                spiffeIDTemplate:
-                  description: SPIFFEID is the SPIFFE ID template. The node and pod
-                    spec are made available to the template under .NodeSpec, .PodSpec
-                    respectively.
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSPIFFEIDSpec defines the desired state of ClusterSPIFFEID
+            properties:
+              admin:
+                description: Admin indicates whether or not the SVID can be used to
+                  access the SPIRE administrative APIs. Extra care should be taken
+                  to only apply this SPIFFE ID to admin workloads.
+                type: boolean
+              dnsNameTemplates:
+                description: DNSNameTemplate represents templates for extra DNS names
+                  that are applicable to SVIDs minted for this ClusterSPIFFEID. The
+                  node and pod spec are made available to the template under .NodeSpec,
+                  .PodSpec respectively.
+                items:
                   type: string
-                ttl:
-                  description: TTL indicates an upper-bound time-to-live for SVIDs minted
-                    for this ClusterSPIFFEID. If unset, a default will be chosen.
+                type: array
+              federatesWith:
+                description: FederatesWith is a list of trust domain names that workloads
+                  that obtain this SPIFFE ID will federate with.
+                items:
                   type: string
-                workloadSelectorTemplates:
-                  description: WorkloadSelectorTemplates are templates to produce arbitrary
-                    workload selectors that apply to a given workload before it will
-                    receive this SPIFFE ID. The rendered value is interpreted by SPIRE
-                    and are of the form type:value, where the value may, and often does,
-                    contain semicolons, .e.g., k8s:container-image:docker/hello-world
-                    The node and pod spec are made available to the template under .NodeSpec,
-                    .PodSpec respectively.
-                  items:
-                    type: string
-                  type: array
-              required:
-                - spiffeIDTemplate
-              type: object
-            status:
-              description: ClusterSPIFFEIDStatus defines the observed state of ClusterSPIFFEID
-              properties:
-                stats:
-                  description: Stats produced by the last entry reconciliation run
-                  properties:
-                    entriesMasked:
-                      description: How many entries were masked by entries for other
-                        ClusterSPIFFEIDs. This happens when one or more ClusterSPIFFEIDs
-                        produce an entry for the same pod with the same set of workload
-                        selectors.
-                      type: integer
-                    entriesToSet:
-                      description: How many entries are to be set for this ClusterSPIFFEID.
-                        In nominal conditions, this should reflect the number of pods
-                        selected, but not always if there were problems encountered
-                        rendering an entry for the pod (RenderFailures) or entries are
-                        masked (EntriesMasked).
-                      type: integer
-                    entryFailures:
-                      description: How many entries were unable to be set due to failures
-                        to create or update the entries via the SPIRE Server API.
-                      type: integer
-                    namespacesIgnored:
-                      description: How many (selected) namespaces were ignored (based
-                        on configuration).
-                      type: integer
-                    namespacesSelected:
-                      description: How many namespaces were selected.
-                      type: integer
-                    podEntryRenderFailures:
-                      description: How many failures were encountered rendering an entry
-                        selected pods. This could be due to either a bad template in
-                        the ClusterSPIFFEID or Pod metadata that when applied to the
-                        template did not produce valid entry values.
-                      type: integer
-                    podsSelected:
-                      description: How many pods were selected out of the namespaces.
-                      type: integer
-                  type: object
-              type: object
-          type: object
-      served: true
-      storage: true
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector selects the namespaces that are targetted
+                  by this CRD.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              podSelector:
+                description: PodSelector selects the pods that are targetted by this
+                  CRD.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              spiffeIDTemplate:
+                description: SPIFFEID is the SPIFFE ID template. The node and pod
+                  spec are made available to the template under .NodeSpec, .PodSpec
+                  respectively.
+                type: string
+              ttl:
+                description: TTL indicates an upper-bound time-to-live for SVIDs minted
+                  for this ClusterSPIFFEID. If unset, a default will be chosen.
+                type: string
+              workloadSelectorTemplates:
+                description: WorkloadSelectorTemplates are templates to produce arbitrary
+                  workload selectors that apply to a given workload before it will
+                  receive this SPIFFE ID. The rendered value is interpreted by SPIRE
+                  and are of the form type:value, where the value may, and often does,
+                  contain semicolons, .e.g., k8s:container-image:docker/hello-world
+                  The node and pod spec are made available to the template under .NodeSpec,
+                  .PodSpec respectively.
+                items:
+                  type: string
+                type: array
+            required:
+            - spiffeIDTemplate
+            type: object
+          status:
+            description: ClusterSPIFFEIDStatus defines the observed state of ClusterSPIFFEID
+            properties:
+              stats:
+                description: Stats produced by the last entry reconciliation run
+                properties:
+                  entriesMasked:
+                    description: How many entries were masked by entries for other
+                      ClusterSPIFFEIDs. This happens when one or more ClusterSPIFFEIDs
+                      produce an entry for the same pod with the same set of workload
+                      selectors.
+                    type: integer
+                  entriesToSet:
+                    description: How many entries are to be set for this ClusterSPIFFEID.
+                      In nominal conditions, this should reflect the number of pods
+                      selected, but not always if there were problems encountered
+                      rendering an entry for the pod (RenderFailures) or entries are
+                      masked (EntriesMasked).
+                    type: integer
+                  entryFailures:
+                    description: How many entries were unable to be set due to failures
+                      to create or update the entries via the SPIRE Server API.
+                    type: integer
+                  namespacesIgnored:
+                    description: How many (selected) namespaces were ignored (based
+                      on configuration).
+                    type: integer
+                  namespacesSelected:
+                    description: How many namespaces were selected.
+                    type: integer
+                  podEntryRenderFailures:
+                    description: How many failures were encountered rendering an entry
+                      selected pods. This could be due to either a bad template in
+                      the ClusterSPIFFEID or Pod metadata that when applied to the
+                      template did not produce valid entry values.
+                    type: integer
+                  podsSelected:
+                    description: How many pods were selected out of the namespaces.
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
The demo configuration was not updated to include updates to the CRD YAML after the status subresource was added. This causes the status update to fail when running an environment based on the demo.

Fixes: #33

Signed-off-by: Andrew Harding <aharding@vmware.com>