### PR TITLE
Fix example, add syntax highlighting

### DIFF
--- a/docs/clusterfederatedtrustdomain-crd.md
+++ b/docs/clusterfederatedtrustdomain-crd.md
@@ -34,7 +34,7 @@ The ClusterFederatedTrustDomain does not have any status fields.
 
 1. Create a federation relationship with the "backend" trust domain using the [https_web](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#521-web-pki-https_web) profile.
 
-    ```
+    ```yaml
     apiVersion: spire.spiffe.io/v1alpha1
     kind: ClusterFederatedTrustDomain
     metadata:
@@ -48,7 +48,7 @@ The ClusterFederatedTrustDomain does not have any status fields.
 
 1. Create a federation relationship with the "backend" trust domain using the [https_spiffe](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#522-spiffe-authentication-https_spiffe) profile, including the initial bundle contents to authenticate the endpoint:
 
-    ```
+    ```yaml
     apiVersion: spire.spiffe.io/v1alpha1
     kind: ClusterFederatedTrustDomain
     metadata:

--- a/docs/clusterspiffeid-crd.md
+++ b/docs/clusterspiffeid-crd.md
@@ -63,7 +63,7 @@ The following data is available to the template:
 
 1. Apply an Istio-style SPIFFE ID to workloads running in namespaces with the "backend" label:
 
-    ```
+    ```yaml
     apiVersion: spire.spiffe.io/v1alpha1
     kind: ClusterSPIFFEID
     metadata:
@@ -72,12 +72,12 @@ The following data is available to the template:
       spiffeIDTemplate: "spiffe://domain.test/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
       namespaceSelector:
         matchLabels:
-          backend: true
+          backend: "true"
     ```
 
 1. Federate workloads running the pods with the "banking" label with the "auditing" trust domain.
 
-    ```
+    ```yaml
     apiVersion: spire.spiffe.io/v1alpha1
     kind: ClusterSPIFFEID
     metadata:
@@ -86,6 +86,6 @@ The following data is available to the template:
       spiffeIDTemplate: "spiffe://domain.test/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
       podSelector:
         matchLabels:
-          banking: true
+          banking: "true"
       federatesWith: ["auditing"]
     ```


### PR DESCRIPTION
The example yamls are missing quotes around the selector value, was getting this error trying to apply them:

```
The ClusterSPIFFEID "backend-workloads" is invalid: spec.podSelector.matchLabels.banking: Invalid value: "boolean": spec.podSelector.matchLabels.banking in body must be of type string: "boolean"
```
Also adds yaml syntax highlighting.