### PR TITLE
Bump Go to 1.19.5-alpine for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
-
+FROM golang:1.19.5-alpine as builder
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod


### PR DESCRIPTION
Switched to alpine as we will have same like we will do for spiffe-csi and spire images. Also see #51 

Supercedes and closes #46
fixes #42 