### PR TITLE
Bump actions to latest releases

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: 1.19
       - name: Build image
         run: make docker-build
       - name: Log in to GHCR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: 1.19
       - name: Build image
@@ -17,7 +17,7 @@ jobs:
       - name: Export image
         run: docker save ghcr.io/spiffe/spire-controller-manager:devel | gzip > image.tar.gz
       - name: Archive image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: image
           path: image.tar.gz
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
       - name: Download archived image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3.0.2
         with:
           name: image
           path: .

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: 1.19
       - name: Build image
@@ -18,7 +18,7 @@ jobs:
       - name: Export image
         run: docker save ghcr.io/spiffe/spire-controller-manager:devel | gzip > image.tar.gz
       - name: Archive image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: image
           path: image.tar.gz
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.2.0
       - name: Download archived image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3.0.2
         with:
           name: image
           path: .
@@ -44,20 +44,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.19
+        uses: actions/checkout@v3.2.0
       - name: Download archived image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3.0.2
         with:
           name: image
           path: .
       - name: Load archived image
         run: zcat image.tar.gz | docker load
       - name: Log in to GHCR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
To get rid of the deprecation notices on set-output

<img width="905" alt="image" src="https://user-images.githubusercontent.com/694733/212631699-f7de1ec0-ae5f-4139-8d92-68c402079c3b.png">

https://github.com/marcofranssen/spire-controller-manager/actions/runs/3913393959/jobs/6689278966