### PR TITLE
Update ENVTEST_K8S_VERSION to 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DIR := ${CURDIR}
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/spiffe/spire-controller-manager:devel
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
+ENVTEST_K8S_VERSION = 1.24
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
Seeing the following error with `make test`, updating this version to 1.24 fixes the issue.

```
 ✗ make test
/Users/fmemon/github.com/faisal-memon/spire-controller-manager/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/Users/fmemon/github.com/faisal-memon/spire-controller-manager/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
unable to find a version that was supported for platform darwin/arm64
```

Signed-off-by: Faisal Memon <fymemon@yahoo.com>