### PR TITLE
Wait 5 seconds for SPIRE Server socket to be available

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,6 +183,7 @@ func run(ctrlConfig spirev1alpha1.ControllerManagerConfig, options ctrl.Options)
 		setupLog.Error(err, "invalid trust domain name")
 		return err
 	}
+	setupLog.Info("Dialing SPIRE Server socket")
 	spireClient, err := spireapi.DialSocket(ctx, ctrlConfig.SPIREServerSocketPath)
 	if err != nil {
 		setupLog.Error(err, "unable to dial SPIRE Server socket")

--- a/pkg/spireapi/client.go
+++ b/pkg/spireapi/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -41,7 +42,10 @@ func DialSocket(ctx context.Context, path string) (Client, error) {
 	} else {
 		target = "unix:" + path
 	}
-	grpcClient, err := grpc.DialContext(ctx, target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	grpcClient, err := grpc.DialContext(ctx, target, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial API socket: %w", err)
 	}


### PR DESCRIPTION
Block on dialing SPIRE Server socket with a 5 second timeout.

fixes https://github.com/spiffe/spire-controller-manager/issues/39

Signed-off-by: Faisal Memon <fymemon@yahoo.com>