### PR TITLE
Update spire-agent daemonset to use node IP from downward API (#4147)

### DIFF
--- a/demo/config/cluster1/spire/spire-agent.yaml
+++ b/demo/config/cluster1/spire/spire-agent.yaml
@@ -71,6 +71,7 @@ data:
       WorkloadAttestor "k8s" {
         plugin_data {
           skip_kubelet_verification = true
+          node_name_env = "MY_NODE_NAME"
         }
       }
     }
@@ -105,6 +106,11 @@ spec:
           image: ghcr.io/spiffe/spire-agent:1.2.3
           imagePullPolicy: IfNotPresent
           args: ["-config", "/run/spire/config/agent.conf"]
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config

--- a/demo/config/cluster2/spire/spire-agent.yaml
+++ b/demo/config/cluster2/spire/spire-agent.yaml
@@ -71,6 +71,7 @@ data:
       WorkloadAttestor "k8s" {
         plugin_data {
           skip_kubelet_verification = true
+          node_name_env = "MY_NODE_NAME"
         }
       }
     }
@@ -105,6 +106,11 @@ spec:
           image: ghcr.io/spiffe/spire-agent:1.2.3
           imagePullPolicy: IfNotPresent
           args: ["-config", "/run/spire/config/agent.conf"]
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config


### PR DESCRIPTION
Fixes issue [#4147](https://github.com/spiffe/spire/issues/4147) in the spire repo. The spire-agent daemonsets in the examples defaults to using localhost to reach the kubelet API. This fails in some cases and this PR fixes the issue by retrieving the node IP using the downward API and passing it to the spire-agent daemonset configuration.

The issue is raised in the spire repo but fixes span across spire-examples, spire-tutorials and spire-controller-manager repos under the SPIFFE org.
