### PR TITLE
Handle missing spire CRDs

### DIFF
--- a/pkg/k8sapi/helpers.go
+++ b/pkg/k8sapi/helpers.go
@@ -21,13 +21,14 @@ import (
 
 	spirev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func ListClusterStaticEntries(ctx context.Context, c client.Client) ([]spirev1alpha1.ClusterStaticEntry, error) {
 	var list spirev1alpha1.ClusterStaticEntryList
-	if err := c.List(ctx, &list); err != nil {
+	if err := listObjectsIgnoreNoMatch(ctx, c, &list); err != nil {
 		return nil, err
 	}
 	return list.Items, nil
@@ -35,7 +36,7 @@ func ListClusterStaticEntries(ctx context.Context, c client.Client) ([]spirev1al
 
 func ListClusterSPIFFEIDs(ctx context.Context, c client.Client) ([]spirev1alpha1.ClusterSPIFFEID, error) {
 	var list spirev1alpha1.ClusterSPIFFEIDList
-	if err := c.List(ctx, &list); err != nil {
+	if err := listObjectsIgnoreNoMatch(ctx, c, &list); err != nil {
 		return nil, err
 	}
 	return list.Items, nil
@@ -43,7 +44,7 @@ func ListClusterSPIFFEIDs(ctx context.Context, c client.Client) ([]spirev1alpha1
 
 func ListClusterFederatedTrustDomains(ctx context.Context, c client.Client) ([]spirev1alpha1.ClusterFederatedTrustDomain, error) {
 	var list spirev1alpha1.ClusterFederatedTrustDomainList
-	if err := c.List(ctx, &list); err != nil {
+	if err := listObjectsIgnoreNoMatch(ctx, c, &list); err != nil {
 		return nil, err
 	}
 	return list.Items, nil
@@ -73,4 +74,12 @@ func ListNamespacePods(ctx context.Context, c client.Client, namespace string, p
 		return nil, err
 	}
 	return list.Items, nil
+}
+
+func listObjectsIgnoreNoMatch(ctx context.Context, c client.Client, objectList client.ObjectList, opts ...client.ListOption) error {
+	err := c.List(ctx, objectList, opts...)
+	if meta.IsNoMatchError(err) {
+		err = nil
+	}
+	return err
 }

--- a/pkg/spireentry/reconciler.go
+++ b/pkg/spireentry/reconciler.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"regexp"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -98,15 +97,10 @@ func (r *entryReconciler) reconcile(ctx context.Context) {
 	// Load and add entry state for ClusterStaticEntries
 	clusterStaticEntries, err := r.listClusterStaticEntries(ctx)
 	if err != nil {
-		if !strings.Contains(err.Error(), "no matches for kind") {
-			log.Error(err, "Failed to list ClusterStaticEntries")
-			return
-		} else {
-			log.Info("ClusterStaticEntry CRD not installed")
-		}
-	} else {
-		r.addClusterStaticEntryEntriesState(ctx, state, clusterStaticEntries)
+		log.Error(err, "Failed to list ClusterStaticEntries")
+		return
 	}
+	r.addClusterStaticEntryEntriesState(ctx, state, clusterStaticEntries)
 
 	// Load and add entry state for ClusterSPIFFEIDs
 	clusterSPIFFEIDs, err := r.listClusterSPIFFEIDs(ctx)

--- a/pkg/spireentry/reconciler.go
+++ b/pkg/spireentry/reconciler.go
@@ -98,10 +98,15 @@ func (r *entryReconciler) reconcile(ctx context.Context) {
 	// Load and add entry state for ClusterStaticEntries
 	clusterStaticEntries, err := r.listClusterStaticEntries(ctx)
 	if err != nil {
-		log.Error(err, "Failed to list ClusterStaticEntries")
-		return
+		if !strings.Contains(err.Error(), "no matches for kind") {
+			log.Error(err, "Failed to list ClusterStaticEntries")
+			return
+		} else {
+			log.Info("ClusterStaticEntry CRD not installed")
+		}
+	} else {
+		r.addClusterStaticEntryEntriesState(ctx, state, clusterStaticEntries)
 	}
-	r.addClusterStaticEntryEntriesState(ctx, state, clusterStaticEntries)
 
 	// Load and add entry state for ClusterSPIFFEIDs
 	clusterSPIFFEIDs, err := r.listClusterSPIFFEIDs(ctx)


### PR DESCRIPTION
This addresses #177 

Checks for existence of each of the spire CRD types and does not start the reconciler if the CRD does not exist. Obviously, could limit this to just the new type `ClusterStaticEntryReconciler`.


Modified to watch for `CustomResourceDefintion` additions - once all of the required CRDs are present the controller will exit and reinitialize with all controller capability.