### PR TITLE
adding support for JWT SVID TTL 

### DIFF
--- a/api/v1alpha1/clusterspiffeid_types.go
+++ b/api/v1alpha1/clusterspiffeid_types.go
@@ -32,9 +32,13 @@ type ClusterSPIFFEIDSpec struct {
 	// available to the template under .NodeSpec, .PodSpec respectively.
 	SPIFFEIDTemplate string `json:"spiffeIDTemplate"`
 
-	// TTL indicates an upper-bound time-to-live for SVIDs minted for this
+	// TTL indicates an upper-bound time-to-live for X509 SVIDs minted for this
 	// ClusterSPIFFEID. If unset, a default will be chosen.
 	TTL metav1.Duration `json:"ttl,omitempty"`
+
+	// JWTTTL indicates an upper-bound time-to-live for JWT SVIDs minted for this
+	// ClusterSPIFFEID.
+	JWTTTL metav1.Duration `json:"jwtTtl,omitempty"`
 
 	// DNSNameTemplate represents templates for extra DNS names that are
 	// applicable to SVIDs minted for this ClusterSPIFFEID.

--- a/api/v1alpha1/clusterspiffeid_webhook.go
+++ b/api/v1alpha1/clusterspiffeid_webhook.go
@@ -86,6 +86,7 @@ type ParsedClusterSPIFFEIDSpec struct {
 	NamespaceSelector         labels.Selector
 	PodSelector               labels.Selector
 	TTL                       time.Duration
+	JWTTTL                    time.Duration
 	FederatesWith             []spiffeid.TrustDomain
 	DNSNameTemplates          []*template.Template
 	WorkloadSelectorTemplates []*template.Template
@@ -152,6 +153,7 @@ func ParseClusterSPIFFEIDSpec(spec *ClusterSPIFFEIDSpec) (*ParsedClusterSPIFFEID
 		NamespaceSelector:         namespaceSelector,
 		PodSelector:               podSelector,
 		TTL:                       spec.TTL.Duration,
+		JWTTTL:                    spec.JWTTTL.Duration,
 		FederatesWith:             federatesWith,
 		DNSNameTemplates:          dnsNameTemplates,
 		WorkloadSelectorTemplates: workloadSelectorTemplates,

--- a/config/crd/bases/spire.spiffe.io_clusterspiffeids.yaml
+++ b/config/crd/bases/spire.spiffe.io_clusterspiffeids.yaml
@@ -58,6 +58,10 @@ spec:
                 items:
                   type: string
                 type: array
+              jwtTtl:
+                description: JWTTTL indicates an upper-bound time-to-live for JWT
+                  SVIDs minted for this ClusterSPIFFEID.
+                type: string
               namespaceSelector:
                 description: NamespaceSelector selects the namespaces that are targeted
                   by this CRD.
@@ -156,8 +160,8 @@ spec:
                   respectively.
                 type: string
               ttl:
-                description: TTL indicates an upper-bound time-to-live for SVIDs minted
-                  for this ClusterSPIFFEID. If unset, a default will be chosen.
+                description: TTL indicates an upper-bound time-to-live for X509 SVIDs
+                  minted for this ClusterSPIFFEID. If unset, a default will be chosen.
                 type: string
               workloadSelectorTemplates:
                 description: WorkloadSelectorTemplates are templates to produce arbitrary

--- a/demo/config/cluster1/crd/spire.spiffe.io_clusterspiffeids.yaml
+++ b/demo/config/cluster1/crd/spire.spiffe.io_clusterspiffeids.yaml
@@ -57,6 +57,10 @@ spec:
                 items:
                   type: string
                 type: array
+              jwtTtl:
+                description: JWTTTL indicates an upper-bound time-to-live for JWT
+                  SVIDs minted for this ClusterSPIFFEID.
+                type: string
               namespaceSelector:
                 description: NamespaceSelector selects the namespaces that are targetted
                   by this CRD.

--- a/demo/config/cluster2/crd/spire.spiffe.io_clusterspiffeids.yaml
+++ b/demo/config/cluster2/crd/spire.spiffe.io_clusterspiffeids.yaml
@@ -57,6 +57,10 @@ spec:
                 items:
                   type: string
                 type: array
+              jwtTtl:
+                description: JWTTTL indicates an upper-bound time-to-live for JWT
+                  SVIDs minted for this ClusterSPIFFEID.
+                type: string
               namespaceSelector:
                 description: NamespaceSelector selects the namespaces that are targetted
                   by this CRD.

--- a/docs/clusterspiffeid-crd.md
+++ b/docs/clusterspiffeid-crd.md
@@ -22,7 +22,7 @@ The definition can be found [here](../api/v1alpha1/clusterspiffeid_types.go).
 | `dnsNameTemplates`          | OPTIONAL | One or more templates used to render DNS names for the target workload. See [Templates](#templates). |
 | `workloadSelectorTemplates` | OPTIONAL | One or more templates used to render additional selectors for the target workload. See [Templates](#templates). |
 | `ttl`                       | OPTIONAL | Duration value indicating an upper bound on the time-to-live for X509-SVIDs issued to target workload |
-| `jwtTtl`                     | OPTIONAL | Duration value indicating an upper bound on the time-to-live for JWT-SVIDs issued to target workload |
+| `jwtTtl`                    | OPTIONAL | Duration value indicating an upper bound on the time-to-live for JWT-SVIDs issued to target workload |
 | `federatesWith`             | OPTIONAL | One or more trust domain names that target workloads federate with |
 | `admin`                     | OPTIONAL | Indicates whether the target workload is an admin workload (i.e. can access SPIRE administrative APIs) |
 | `downstream`                | OPTIONAL | Indicates that the entry describes a downstream SPIRE server. |

--- a/docs/clusterspiffeid-crd.md
+++ b/docs/clusterspiffeid-crd.md
@@ -21,7 +21,8 @@ The definition can be found [here](../api/v1alpha1/clusterspiffeid_types.go).
 | `namespaceSelector`         | OPTIONAL | A label selector used to scope which workload namespaces this ClusterSPIFFEID targets |
 | `dnsNameTemplates`          | OPTIONAL | One or more templates used to render DNS names for the target workload. See [Templates](#templates). |
 | `workloadSelectorTemplates` | OPTIONAL | One or more templates used to render additional selectors for the target workload. See [Templates](#templates). |
-| `ttl`                       | OPTIONAL | Duration value indicating an upper bound on the time-to-live for SVIDs issued to target workload |
+| `ttl`                       | OPTIONAL | Duration value indicating an upper bound on the time-to-live for X509-SVIDs issued to target workload |
+| `jwtTtl`                     | OPTIONAL | Duration value indicating an upper bound on the time-to-live for JWT-SVIDs issued to target workload |
 | `federatesWith`             | OPTIONAL | One or more trust domain names that target workloads federate with |
 | `admin`                     | OPTIONAL | Indicates whether the target workload is an admin workload (i.e. can access SPIRE administrative APIs) |
 | `downstream`                | OPTIONAL | Indicates that the entry describes a downstream SPIRE server. |

--- a/pkg/spireentry/entries.go
+++ b/pkg/spireentry/entries.go
@@ -119,6 +119,7 @@ func renderPodEntry(spec *spirev1alpha1.ParsedClusterSPIFFEIDSpec, node *corev1.
 		ParentID:      parentID,
 		Selectors:     selectors,
 		X509SVIDTTL:   spec.TTL,
+		JWTSVIDTTL:    spec.JWTTTL,
 		FederatesWith: spec.FederatesWith,
 		DNSNames:      dnsNames,
 		Admin:         spec.Admin,

--- a/pkg/spireentry/entries_test.go
+++ b/pkg/spireentry/entries_test.go
@@ -2,7 +2,6 @@ package spireentry
 
 import (
 	"testing"
-
 	"time"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"

--- a/pkg/spireentry/entries_test.go
+++ b/pkg/spireentry/entries_test.go
@@ -3,6 +3,8 @@ package spireentry
 import (
 	"testing"
 
+	"time"
+
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	spirev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
 	"github.com/stretchr/testify/require"
@@ -63,4 +65,37 @@ func TestRenderPodEntry(t *testing.T) {
 	require.Len(t, entry.DNSNames, len(spec.DNSNameTemplates)-1)
 	require.Contains(t, entry.DNSNames, pod.Name+"."+pod.Namespace+".svc."+clusterDomain)
 	require.Contains(t, entry.DNSNames, pod.Name+"."+trustDomain+".svc")
+}
+
+func TestJWTTTLInRenderPodEntry(t *testing.T) {
+	spec := &spirev1alpha1.ClusterSPIFFEIDSpec{
+		SPIFFEIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}",
+		JWTTTL:           metav1.Duration{Duration: time.Duration(60)},
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "uid",
+		},
+		Spec: corev1.NodeSpec{},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "namespace",
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "test",
+		},
+	}
+
+	parsedSpec, err := spirev1alpha1.ParseClusterSPIFFEIDSpec(spec)
+	require.NoError(t, err)
+	td, err := spiffeid.TrustDomainFromString(trustDomain)
+	require.NoError(t, err)
+
+	entry, err := renderPodEntry(parsedSpec, node, pod, td, clusterName, clusterDomain)
+	require.NoError(t, err)
+
+	require.Equal(t, entry.JWTSVIDTTL.Nanoseconds(), spec.JWTTTL.Nanoseconds())
 }


### PR DESCRIPTION
- added `JWTTTL` to `ClusterSPIFFEIDSpec`
- added `JWTTTL` to `renderPodEntry` func
- added test to check if entry JWT TTL matches the passed in JWT TTL
- closes #65 