### PR TITLE
Move base image for controlelr-manager to gcr.io/distroless/static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 #FROM gcr.io/distroless/static:nonroot
-FROM gcr.io/distroless/base AS spire-controller-manager
+FROM gcr.io/distroless/static AS spire-controller-manager
 WORKDIR /
 ENTRYPOINT ["/spire-controller-manager"]
 CMD []


### PR DESCRIPTION
 gcr.io/distroless/base includes some [binaries](https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md)  that can cause alerts
in some security review application (glibc & openssl) 
Since we are not using those binaries, moving to `gcr.io/distroless/static` to clean those dependencies sounds safe 
