### PR TITLE
Add back in the removed status subresource definitions

### DIFF
--- a/config/crd/bases/spire.spiffe.io_clusterfederatedtrustdomains.yaml
+++ b/config/crd/bases/spire.spiffe.io_clusterfederatedtrustdomains.yaml
@@ -88,3 +88,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/spire.spiffe.io_clusterspiffeids.yaml
+++ b/config/crd/bases/spire.spiffe.io_clusterspiffeids.yaml
@@ -223,3 +223,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/spire.spiffe.io_clusterstaticentries.yaml
+++ b/config/crd/bases/spire.spiffe.io_clusterstaticentries.yaml
@@ -89,3 +89,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
Something is up with our manifest generation, wherein it is not properly producing the status subresource definitions. We need to figure out why. In the meantime, patch the generated manifests to include the status subresource. Otherwise folks get "not found" errors when trying to update status.

We'll need to keep a close watch on future PRs backing this out until we can figure out what's wrong.