### PR TITLE
reconciler: don't delete join token based entries

### DIFF
--- a/pkg/spireentry/reconciler.go
+++ b/pkg/spireentry/reconciler.go
@@ -29,12 +29,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	spirev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
-	"github.com/spiffe/spire-controller-manager/pkg/k8sapi"
-	"github.com/spiffe/spire-controller-manager/pkg/namespace"
-	"github.com/spiffe/spire-controller-manager/pkg/reconciler"
-	"github.com/spiffe/spire-controller-manager/pkg/spireapi"
-
 	"google.golang.org/grpc/codes"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -42,15 +36,23 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	spirev1alpha1 "github.com/spiffe/spire-controller-manager/api/v1alpha1"
+	"github.com/spiffe/spire-controller-manager/pkg/k8sapi"
+	"github.com/spiffe/spire-controller-manager/pkg/namespace"
+	"github.com/spiffe/spire-controller-manager/pkg/reconciler"
+	"github.com/spiffe/spire-controller-manager/pkg/spireapi"
 )
 
 const (
-	// joinTokenSpiffeSubstr is the substring that is the part of the parent SPIFFE ID for join token entries.
+	// joinTokenSpiffePrefix is the prefix that is the part of the parent SPIFFE ID for join token entries.
 	// Ref: https://github.com/spiffe/spire/blob/v1.8.7/pkg/server/api/agent/v1/service.go#L714
-	joinTokenSpiffeSubstr = "/spire/agent/join_token/"
+	// nolint: gosec // not a credential
+	joinTokenSpiffePrefix = "/spire/agent/join_token/"
 
 	// joinTokenSelectorType is the selector type used in the selector for join token entries.
 	// Ref: https://github.com/spiffe/spire/blob/v1.8.7/pkg/server/api/agent/v1/service.go#L515
+	// nolint: gosec // not a credential
 	joinTokenSelectorType = "spiffe_id"
 )
 
@@ -645,7 +647,7 @@ func idsFromEntries(entries []spireapi.Entry) []string {
 func filterJoinTokenEntries(entries []spireapi.Entry) []spireapi.Entry {
 	if len(entries) == 0 {
 		return entries
-	}	
+	}
 	filteredEntries := make([]spireapi.Entry, 0, len(entries))
 	for _, entry := range entries {
 		if isJoinTokenEntry(entry) {
@@ -661,7 +663,7 @@ func filterJoinTokenEntries(entries []spireapi.Entry) []spireapi.Entry {
 // 1. The path of the parent ID of the entry must begin with "/spire/agent/join_token/".
 // 2. The entry must contain a selector of type "spiffe_id".
 func isJoinTokenEntry(entry spireapi.Entry) bool {
-	if !strings.HasPrefix(entry.ParentID.Path(), joinTokenSpiffeSubstr) {
+	if !strings.HasPrefix(entry.ParentID.Path(), joinTokenSpiffePrefix) {
 		return false
 	}
 	for _, selector := range entry.Selectors {

--- a/pkg/spireentry/reconciler.go
+++ b/pkg/spireentry/reconciler.go
@@ -643,7 +643,10 @@ func idsFromEntries(entries []spireapi.Entry) []string {
 
 // filterJoinTokenEntries filters out entries that correspond to join tokens.
 func filterJoinTokenEntries(entries []spireapi.Entry) []spireapi.Entry {
-	var filteredEntries []spireapi.Entry
+	if len(entries) == 0 {
+		return entries
+	}	
+	filteredEntries := make([]spireapi.Entry, 0, len(entries))
 	for _, entry := range entries {
 		if isJoinTokenEntry(entry) {
 			continue
@@ -655,10 +658,10 @@ func filterJoinTokenEntries(entries []spireapi.Entry) []spireapi.Entry {
 
 // isJoinTokenEntry returns true if the entry corresponds to a join token.
 // For an entry to correspond to a join token, both the following conditions must be true:
-// 1. The parent ID of the entry must contain the substring "/spire/agent/join_token/".
+// 1. The path of the parent ID of the entry must begin with "/spire/agent/join_token/".
 // 2. The entry must contain a selector of type "spiffe_id".
 func isJoinTokenEntry(entry spireapi.Entry) bool {
-	if !strings.Contains(entry.ParentID.String(), joinTokenSpiffeSubstr) {
+	if !strings.HasPrefix(entry.ParentID.Path(), joinTokenSpiffeSubstr) {
 		return false
 	}
 	for _, selector := range entry.Selectors {


### PR DESCRIPTION
Updates the reconciler to ignore the deletion of join token based entries since join tokens are created out-of-band and can be used in conjunction with the controller-manager.

Resolves #247