### PR TITLE
Use go-version-file in Setup go actions

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -4,8 +4,6 @@ on:
     # Random minute number to avoid GH scheduler stampede
     - cron: '37 21 * * *'
   workflow_dispatch: {}
-env:
-  GO_VERSION: 1.22.2
 
 jobs:
   build-and-publish-images:
@@ -22,7 +20,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -2,8 +2,6 @@ name: PR Build
 on:
   pull_request: {}
   workflow_dispatch: {}
-env:
-  GO_VERSION: 1.22.2
 
 jobs:
   lint:
@@ -15,7 +13,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Lint
         run: make lint
 
@@ -31,7 +29,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Run unit tests
         run: make test
 
@@ -47,7 +45,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -3,9 +3,6 @@ on:
   push:
     tags:
       - 'v[0-9].[0-9]+.[0-9]+'
-env:
-  GO_VERSION: 1.22.2
-
 jobs:
   build-image:
     runs-on: ubuntu-22.04
@@ -19,7 +16,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
**Utilize go-version-file in GitHub Actions for Go Setup:**

This PR updates our GitHub Actions by integrating `go-version-file` to specify the Go version during the setup process. This change ensures that the Go environment is consistent with the version defined in the project configuration.