### PR TITLE
Add default flag to ClusterSPIFFEIDs

### DIFF
--- a/api/v1alpha1/clusterspiffeid_types.go
+++ b/api/v1alpha1/clusterspiffeid_types.go
@@ -78,6 +78,10 @@ type ClusterSPIFFEIDSpec struct {
 	// Set which Controller Class will act on this object
 	// +kubebuilder:validation:Optional
 	ClassName string `json:"className,omitempty"`
+
+	// Apply this ID only if there are no other matching non default ClusterSPIFFEIDs.
+	// +kubebuilder:validation:Optional
+	Default bool `json:"default,omitempty"`
 }
 
 // ClusterSPIFFEIDStatus defines the observed state of ClusterSPIFFEID

--- a/config/crd/bases/spire.spiffe.io_clusterspiffeids.yaml
+++ b/config/crd/bases/spire.spiffe.io_clusterspiffeids.yaml
@@ -52,6 +52,11 @@ spec:
               className:
                 description: Set which Controller Class will act on this object
                 type: string
+              default:
+                description: |-
+                  Apply this ID only if there are no other matching non default
+                  ClusterSPIFFEIDs
+                type: boolean
               dnsNameTemplates:
                 description: |-
                   DNSNameTemplate represents templates for extra DNS names that are


### PR DESCRIPTION
Enables the user to set default ClusterSPIFFEIDs that get applied only when there are no matching non default IDs that match. This makes it significantly easier to configure default IDs on a cluster.