### PR TITLE
Rotate webhook certs on non-leader

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -264,7 +264,7 @@ func run(mainConfig Config) (err error) {
 	// file to keep rotation simple.
 	// TODO: upstream a change to the WebhookServer so it can use callbacks to
 	// obtain the certificates so we don't have to touch disk.
-	var webhookRunnable manager.Runnable
+	var webhookManager *webhookmanager.Manager
 	if webhookEnabled {
 		const keyPairName = "keypair.pem"
 		certDir, err := os.MkdirTemp("", "spire-controller-manager-")
@@ -304,7 +304,7 @@ func run(mainConfig Config) (err error) {
 			return err
 		}
 
-		webhookManager := webhookmanager.New(webhookmanager.Config{
+		webhookManager = webhookmanager.New(webhookmanager.Config{
 			ID:            spiffeid.RequireFromPath(trustDomain, "/spire-controller-manager-webhook"),
 			KeyPairPath:   filepath.Join(certDir, keyPairName),
 			WebhookName:   mainConfig.ctrlConfig.ValidatingWebhookConfigurationName,
@@ -317,8 +317,6 @@ func run(mainConfig Config) (err error) {
 			setupLog.Error(err, "failed to mint initial webhook certificate")
 			return err
 		}
-
-		webhookRunnable = webhookManager
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mainConfig.options)
@@ -432,9 +430,9 @@ func run(mainConfig Config) (err error) {
 		}
 	}
 
-	if webhookRunnable != nil {
-		if err = mgr.Add(webhookRunnable); err != nil {
-			setupLog.Error(err, "unable to manage federation relationship reconciler")
+	if webhookManager != nil {
+		if err = mgr.Add(webhookManager); err != nil {
+			setupLog.Error(err, "unable to manage webhook")
 			return err
 		}
 	}

--- a/pkg/webhookmanager/manager.go
+++ b/pkg/webhookmanager/manager.go
@@ -169,6 +169,10 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 }
 
+func (m *Manager) NeedLeaderElection() bool {
+	return false
+}
+
 func (m *Manager) mintX509SVIDIfNeeded(ctx context.Context, store cache.Store) error {
 	log := log.FromContext(ctx)
 


### PR DESCRIPTION
Webhook processing runs on non-leader pods. So the webhook certificate rotation needs to run regardless of leader status. To do this we have the webhook manger implement the [LeaderElectionRunnable](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#LeaderElectionRunnable) interface and have `NeedLeaderElection()` return false.

fixes #450 