### PR TITLE
Bump versions used in migration guide

### DIFF
--- a/migration/config/spire-server.yaml
+++ b/migration/config/spire-server.yaml
@@ -176,7 +176,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: spire-server
-          image: ghcr.io/spiffe/spire-server:1.7.2
+          image: ghcr.io/spiffe/spire-server:1.11.1
           imagePullPolicy: IfNotPresent
           args: ["-config", "/run/spire/server/config/server.conf"]
           ports:
@@ -190,7 +190,7 @@ spec:
             - name: spire-server-socket
               mountPath: /tmp/spire-server/private
         - name: spire-controller-manager
-          image: ghcr.io/spiffe/spire-controller-manager:nightly
+          image: ghcr.io/spiffe/spire-controller-manager:0.6.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9443


### PR DESCRIPTION
Not sure if this guide is still being used but if it is, might as well keep the versions up to date.