### PR TITLE
Set an initial logger

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -90,6 +90,7 @@ func init() {
 }
 
 func main() {
+	ctrl.SetLogger(zap.New())
 	mainConfig, err := parseConfig()
 	if err != nil {
 		setupLog.Error(err, "error parsing configuration")


### PR DESCRIPTION
main calls parseConfig, which sets the logger. However, parseConfig can return an error before it sets the logger. In that case, main will try to output a log message but the message fails to print because no logger has been set.

This change sets up an initial default zap logger. parseConfig will then re-set the logger to a zap logger using the log settings from the parsed configuration.