### PR TITLE
Fix for webhook error at startup

### DIFF
--- a/pkg/spireapi/client.go
+++ b/pkg/spireapi/client.go
@@ -40,13 +40,19 @@ type GrpcConfig struct {
 
 func DialSocket(path string, grpcConfig *GrpcConfig) (Client, error) {
 	var target string
+	var waitForBundle = `{
+	          "methodConfig": [{
+	            "name": [{"service": "spire.api.server.bundle.v1.Bundle", "method": "GetBundle"}],
+				"waitForReady": true,
+				"timeout": "5s"
+	        }]
+	    }`
 	if filepath.IsAbs(path) {
 		target = "unix://" + path
 	} else {
 		target = "unix:" + path
 	}
-
-	grpcOptions := getGrpcConfig(grpcConfig)
+	grpcOptions := append(getGrpcConfig(grpcConfig), grpc.WithDefaultServiceConfig(waitForBundle))
 
 	grpcClient, err := grpc.NewClient(target, grpcOptions...)
 	if err != nil {


### PR DESCRIPTION
As I reported in #453 the error from #39 came back in v0.6.0 because of #418.
With this solution the GetBundle grpc call will wait 5 seconds for SPIRE Server socket to be available.