### PR TITLE
fix: recover from existing unsupported fields entry

### DIFF
--- a/pkg/spireapi/entryapi.go
+++ b/pkg/spireapi/entryapi.go
@@ -110,7 +110,7 @@ func (c entryClient) GetUnsupportedFields(ctx context.Context, td string) (map[F
 	}
 
 	result := resp.Results[0]
-	if result.Status.Code != int32(codes.OK) {
+	if result.Status.Code != int32(codes.OK) && result.Status.Code != int32(codes.AlreadyExists) {
 		return nil, fmt.Errorf("failed to create entry: %v", result.Status.Message)
 	}
 


### PR DESCRIPTION
I noticed that one of our controller managers was repeatedly giving a "failed to create entry" error. I assume the pod got killed halfway through refreshing the unsupported fields and didn't get cleaned up. If the entry already exists it gets returned in the result so continuing on rather than returning an error if the entry already exists allows the controller manager to recover in this scenario.