### PR TITLE
Fix gcInterval zero-value causing 100% CPU

### DIFF
--- a/api/v1alpha1/controllermanagerconfig_types.go
+++ b/api/v1alpha1/controllermanagerconfig_types.go
@@ -53,7 +53,7 @@ type ControllerManagerConfig struct {
 	// is otherwise idle. This impacts how quickly SPIRE state will converge
 	// after CRDs are removed or SPIRE state is mutated out from underneath
 	// the controller.
-	GCInterval time.Duration `json:"gcInterval"`
+	GCInterval time.Duration `json:"gcInterval,omitempty"`
 
 	// SPIREServerSocketPath is the path to the SPIRE Server API socket
 	SPIREServerSocketPath string `json:"spireServerSocketPath"`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -148,6 +148,9 @@ func parseConfig() (Config, error) {
 		if err := spirev1alpha1.LoadOptionsFromFile(configFileFlag, scheme, &retval.options, &retval.ctrlConfig, expandEnvFlag); err != nil {
 			return retval, fmt.Errorf("unable to load the config file: %w", err)
 		}
+		if retval.ctrlConfig.GCInterval <= 0 {
+			retval.ctrlConfig.GCInterval = defaultGCInterval
+		}
 		for _, ignoredNamespace := range retval.ctrlConfig.IgnoreNamespaces {
 			regex, err := regexp.Compile(ignoredNamespace)
 			if err != nil {


### PR DESCRIPTION
When consumers embed ControllerManagerConfig without explicitly setting GCInterval, Go's zero value (0) is serialized into the config YAML. LoadOptionsFromFile then overwrites the default 10s with 0, causing the GC loop to run continuously with no pause.

This fix:
- Adds omitempty to the gcInterval JSON tag so zero values are omitted
- Adds a defensive check to fall back to defaultGCInterval when gcInterval is <= 0

Fixes #698